### PR TITLE
closes #80 split round display

### DIFF
--- a/src/main/java/nl/hsleiden/ipsene/views/BoardView.java
+++ b/src/main/java/nl/hsleiden/ipsene/views/BoardView.java
@@ -112,8 +112,8 @@ public class BoardView implements View {
     Label playersTurnDisplay = ViewHelper.playersTurnDisplay(turnPlayerNumber);
     ViewHelper.setNodeCoordinates(playersTurnDisplay, 1350, 200);
 
-//    Label roundNumberHeader = ViewHelper.headerLabelBuilder("Round number:");
-//    ViewHelper.setNodeCoordinates(roundNumberHeader, 1375, 280);
+    //    Label roundNumberHeader = ViewHelper.headerLabelBuilder("Round number:");
+    //    ViewHelper.setNodeCoordinates(roundNumberHeader, 1375, 280);
 
     VBox roundNumberDisplay = ViewHelper.roundNumberDisplayBuilder(roundNumber, 1);
     ViewHelper.setNodeCoordinates(roundNumberDisplay, 1375, 280);

--- a/src/main/java/nl/hsleiden/ipsene/views/ViewHelper.java
+++ b/src/main/java/nl/hsleiden/ipsene/views/ViewHelper.java
@@ -20,7 +20,6 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.shape.StrokeType;
 import javafx.scene.text.Text;
 import nl.hsleiden.ipsene.application.Main;
-import nl.hsleiden.ipsene.interfaces.View;
 import nl.hsleiden.ipsene.models.CardType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -203,7 +202,6 @@ public class ViewHelper {
     VBox vbx = new VBox();
     Label roundNumberHeader = ViewHelper.headerLabelBuilder("Round Number:");
 
-
     Label roundNumberLabel = new Label();
     roundNumberLabel.setStyle(css);
     roundNumberLabel.setText(String.valueOf(((roundNumber / 3) + 1)));
@@ -216,7 +214,8 @@ public class ViewHelper {
     subroundNumberLabel.setText(String.valueOf(roundNumber % 3));
     subroundNumberLabel.setTranslateX(55);
 
-    vbx.getChildren().addAll(roundNumberHeader, roundNumberLabel, subroundNumberHeader, subroundNumberLabel);
+    vbx.getChildren()
+        .addAll(roundNumberHeader, roundNumberLabel, subroundNumberHeader, subroundNumberLabel);
 
     return vbx;
   }


### PR DESCRIPTION
Refactored the ViewHelper and BoardView to split the round number display into two.
Old format:
![image](https://user-images.githubusercontent.com/70705167/121681797-85f43000-cabb-11eb-8ed6-805910af9fce.png)
New format:
![image](https://user-images.githubusercontent.com/70705167/121681817-8d1b3e00-cabb-11eb-8aef-60e7db737f2e.png)
